### PR TITLE
feat: retry-after for 429

### DIFF
--- a/index.js
+++ b/index.js
@@ -373,7 +373,9 @@ function retryrequest(nodemodule, requestOptions, body, retryOptions, timeoutOpt
     const attempt = erredAttempt+1;
     if (attempt <= retryOptions.maxAttempts) {
       const maxRetryDelayInSeconds = ('maxRetryDelayInSeconds' in retryOptions) ? retryOptions.maxRetryDelayInSeconds : MAX_RETRY_DELAY_IN_SECONDS;
-      const delayInMilliseconds = Math.min(Math.random() * Math.pow(2, attempt-1), maxRetryDelayInSeconds) * 1000;
+      const retryAfterSeconds = parseInt(err.headers?.['retry-after'], 10); // NaN for the HTTP-date variant of the header
+      const delayInSeconds = Number.isFinite(retryAfterSeconds) ? Math.min(retryAfterSeconds, maxRetryDelayInSeconds) : Math.min(Math.random() * Math.pow(2, attempt-1), maxRetryDelayInSeconds);
+      const delayInMilliseconds = delayInSeconds * 1000;
       contextOptions.emitter?.emit(EVENT_NAME_REQUEST_RETRYING, {traceId: getTraceId(attempt), attempt, delayInMilliseconds, err});
       const abortListener = () => {
         clearTimeout(timeoutId);
@@ -405,6 +407,7 @@ function retryrequest(nodemodule, requestOptions, body, retryOptions, timeoutOpt
           if (res.headers['content-type'] === 'application/xml') {
             const err = new Error(`status code: ${res.statusCode}\n${body.toString('utf8')}`);
             err.statusCode = res.statusCode;
+            err.headers = res.headers;
             err.body = body;
             retry(attempt, err);
           } else {
@@ -414,6 +417,7 @@ function retryrequest(nodemodule, requestOptions, body, retryOptions, timeoutOpt
             }
             const err = new Error(message);
             err.statusCode = res.statusCode;
+            err.headers = res.headers;
             err.body = body;
             retry(attempt, err);
           }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3-getobject-accelerator",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Get large objects from S3 by using parallel byte-range fetches/parts to improve performance.",
   "main": "index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -413,6 +413,96 @@ describe('index', () => {
         }
       });
     });
+    it('retry honors Retry-After header', (done) => {
+      nock('http://localhost')
+        .post('/api')
+        .reply(429, '', {'Retry-After': '1'})
+        .post('/api')
+        .reply(204);
+
+      const start = Date.now();
+      retryrequest(http, {
+        hostname: 'localhost',
+        method: 'POST',
+        path: '/api'
+      }, Buffer.alloc(10), {maxAttempts: 3}, {}, {}, (err, res) => {
+        if (err) {
+          done(err);
+        } else {
+          assert.ok(nock.isDone());
+          assert.deepStrictEqual(res.statusCode, 204);
+          assert.ok(Date.now() - start >= 1000);
+          done();
+        }
+      });
+    });
+    it('retry caps Retry-After header at maxRetryDelayInSeconds', (done) => {
+      nock('http://localhost')
+        .post('/api')
+        .reply(429, '', {'Retry-After': '10'})
+        .post('/api')
+        .reply(204);
+
+      const start = Date.now();
+      retryrequest(http, {
+        hostname: 'localhost',
+        method: 'POST',
+        path: '/api'
+      }, Buffer.alloc(10), {maxAttempts: 3, maxRetryDelayInSeconds: 1}, {}, {}, (err, res) => {
+        if (err) {
+          done(err);
+        } else {
+          assert.ok(nock.isDone());
+          assert.deepStrictEqual(res.statusCode, 204);
+          const elapsed = Date.now() - start;
+          assert.ok(elapsed >= 1000 && elapsed < 10000);
+          done();
+        }
+      });
+    });
+    it('retry ignores HTTP-date Retry-After header', (done) => {
+      nock('http://localhost')
+        .post('/api')
+        .reply(429, '', {'Retry-After': 'Wed, 08 Jul 2026 07:28:00 GMT'})
+        .post('/api')
+        .reply(204);
+
+      retryrequest(http, {
+        hostname: 'localhost',
+        method: 'POST',
+        path: '/api'
+      }, Buffer.alloc(10), {maxAttempts: 3, maxRetryDelayInSeconds: 1}, {}, {}, (err, res) => {
+        if (err) {
+          done(err);
+        } else {
+          assert.ok(nock.isDone());
+          assert.deepStrictEqual(res.statusCode, 204);
+          done();
+        }
+      });
+    });
+    it('retry fail exposes statusCode, headers, and body', (done) => {
+      nock('http://localhost')
+        .post('/api')
+        .times(3)
+        .reply(429, 'rate limited', {'Retry-After': '1', 'content-type': 'text/plain'});
+
+      retryrequest(http, {
+        hostname: 'localhost',
+        method: 'POST',
+        path: '/api'
+      }, Buffer.alloc(10), {maxAttempts: 3}, {}, {}, (err) => {
+        if (err) {
+          assert.ok(nock.isDone());
+          assert.deepStrictEqual(err.statusCode, 429);
+          assert.deepStrictEqual(err.headers['retry-after'], '1');
+          assert.deepStrictEqual(err.body.toString('utf8'), 'rate limited');
+          done();
+        } else {
+          done(new Error('must error'));
+        }
+      });
+    });
     describe('timeout', () => {
       it('connection', (done) => {
         nock('http://localhost')


### PR DESCRIPTION
Slow down retries after `429 Too Many Requests` by considering `retry-after` header.